### PR TITLE
Fix responsive layout of sections and lazy-load images

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,40 +64,40 @@
             <div>
               <!-- Pre Pre Dies -->
               <div class="actual-photos" id="pre-pre-dies">
-                <div> <img src="images-optimized/pre-pre-dies/DSC_0115_result.png" width="250" />Marleen</div>
-                <div> <img src="images-optimized/pre-pre-dies/DSC_0116_result.png" width="250" />Marleen, Vera and Louise</div>
-                <div> <img src="images-optimized/pre-pre-dies/DSC_0121_result.png" width="250" />Yeaass PIE</div>
-                <div> <img src="images-optimized/pre-pre-dies/DSC_0124_result.png" width="250" />Daniel</div>
-                <div> <img src="images-optimized/pre-pre-dies/DSC_0126_result.png" width="250" />Thomas and Karim</div>
-                <div> <img src="images-optimized/pre-pre-dies/DSC_0126_result.png" width="250" />Thomas and Karim</div>
+                <div> <img data-src="images-optimized/pre-pre-dies/DSC_0115_result.png" />Marleen</div>
+                <div> <img data-src="images-optimized/pre-pre-dies/DSC_0116_result.png" />Marleen, Vera and Louise</div>
+                <div> <img data-src="images-optimized/pre-pre-dies/DSC_0121_result.png" />Yeaass PIE</div>
+                <div> <img data-src="images-optimized/pre-pre-dies/DSC_0124_result.png" />Daniel</div>
+                <div> <img data-src="images-optimized/pre-pre-dies/DSC_0126_result.png" />Thomas and Karim</div>
+                <div> <img data-src="images-optimized/pre-pre-dies/DSC_0126_result.png" />Thomas and Karim</div>
               </div>
               <!-- Pre Dies -->
               <div class="actual-photos" id="pre-dies">
-                <div> <img src="images-optimized/pre-dies/IMG_2142_result.png" width="250" /></div>
-                <div> <img src="images-optimized/pre-dies/IMG_2145_result.png" width="250" /></div>
-                <div> <img src="images-optimized/pre-dies/IMG_2148_result.png" width="250" /></div>
-                <div> <img src="images-optimized/pre-dies/IMG_2152_result.png" width="250" /></div>
-                <div> <img src="images-optimized/pre-dies/IMG_2155_result.png" width="250" /></div>
-                <div> <img src="images-optimized/pre-dies/IMG_2156_result.png" width="250" /></div>
-                <div> <img src="images-optimized/pre-dies/IMG_2158_result.png" width="250" /></div>
-                <div> <img src="images-optimized/pre-dies/IMG_2162_result.png" width="250" /></div>
-                <div> <img src="images-optimized/pre-dies/IMG_2176_result.png" width="250" /></div>
-                <div> <img src="images-optimized/pre-dies/IMG_2190_result.png" width="250" /></div>
-                <div> <img src="images-optimized/pre-dies/IMG_2195_result.png" width="250" /></div>
-                <div> <img src="images-optimized/pre-dies/IMG_2196_result.png" width="250" /></div>
-                <div> <img src="images-optimized/pre-dies/IMG_2203_result.png" width="250" /></div>
-                <div> <img src="images-optimized/pre-dies/IMG_2207_result.png" width="250" /></div>
-                <div> <img src="images-optimized/pre-dies/IMG_2212_result.png" width="250" /></div>
-                <div> <img src="images-optimized/pre-dies/IMG_2223_result.png" width="250" /></div>
-                <div> <img src="images-optimized/pre-dies/IMG_2244_result.png" width="250" /></div>
-                <div> <img src="images-optimized/pre-dies/IMG_2250_result.png" width="250" /></div>
-                <div> <img src="images-optimized/pre-dies/IMG_2259_result.png" width="250" /></div>
-                <div> <img src="images-optimized/pre-dies/IMG_2261_result.png" width="250" /></div>
-                <div> <img src="images-optimized/pre-dies/IMG_2271_result.png" width="250" /></div>
-                <div> <img src="images-optimized/pre-dies/IMG_2276_result.png" width="250" /></div>
-                <div> <img src="images-optimized/pre-dies/IMG_2279_result.png" width="250" /></div>
-                <div> <img src="images-optimized/pre-dies/IMG_2283_result.png" width="250" /></div>
-                <div> <img src="images-optimized/pre-dies/IMG_2286_result.png" width="250" /></div>
+                <div> <img data-src="images-optimized/pre-dies/IMG_2142_result.png" /></div>
+                <div> <img data-src="images-optimized/pre-dies/IMG_2145_result.png" /></div>
+                <div> <img data-src="images-optimized/pre-dies/IMG_2148_result.png" /></div>
+                <div> <img data-src="images-optimized/pre-dies/IMG_2152_result.png" /></div>
+                <div> <img data-src="images-optimized/pre-dies/IMG_2155_result.png" /></div>
+                <div> <img data-src="images-optimized/pre-dies/IMG_2156_result.png" /></div>
+                <div> <img data-src="images-optimized/pre-dies/IMG_2158_result.png" /></div>
+                <div> <img data-src="images-optimized/pre-dies/IMG_2162_result.png" /></div>
+                <div> <img data-src="images-optimized/pre-dies/IMG_2176_result.png" /></div>
+                <div> <img data-src="images-optimized/pre-dies/IMG_2190_result.png" /></div>
+                <div> <img data-src="images-optimized/pre-dies/IMG_2195_result.png" /></div>
+                <div> <img data-src="images-optimized/pre-dies/IMG_2196_result.png" /></div>
+                <div> <img data-src="images-optimized/pre-dies/IMG_2203_result.png" /></div>
+                <div> <img data-src="images-optimized/pre-dies/IMG_2207_result.png" /></div>
+                <div> <img data-src="images-optimized/pre-dies/IMG_2212_result.png" /></div>
+                <div> <img data-src="images-optimized/pre-dies/IMG_2223_result.png" /></div>
+                <div> <img data-src="images-optimized/pre-dies/IMG_2244_result.png" /></div>
+                <div> <img data-src="images-optimized/pre-dies/IMG_2250_result.png" /></div>
+                <div> <img data-src="images-optimized/pre-dies/IMG_2259_result.png" /></div>
+                <div> <img data-src="images-optimized/pre-dies/IMG_2261_result.png" /></div>
+                <div> <img data-src="images-optimized/pre-dies/IMG_2271_result.png" /></div>
+                <div> <img data-src="images-optimized/pre-dies/IMG_2276_result.png" /></div>
+                <div> <img data-src="images-optimized/pre-dies/IMG_2279_result.png" /></div>
+                <div> <img data-src="images-optimized/pre-dies/IMG_2283_result.png" /></div>
+                <div> <img data-src="images-optimized/pre-dies/IMG_2286_result.png" /></div>
               </div>
               <!-- Monday -->
               <div class="actual-photos" id="monday">
@@ -302,12 +302,20 @@
     let previousElement;
 
     function showImagesForButton(button) {
-      const imagesElement = document.getElementById(button.innerText.toLowerCase().replace(' ', '-'));
+      const imagesSelector = button.innerText.toLowerCase().replace(' ', '-');
+      const imagesElement = document.getElementById(imagesSelector);
+
       if (previousElement) {
         previousElement.style.display = 'none';
       }
+
       previousElement = imagesElement;
       imagesElement.style.display = 'flex';
+
+      for (const image of document.querySelectorAll(`#${imagesSelector} img[data-src]:not([data-src=""])`)) {
+        image.src = image.dataset.src;
+        image.dataset.src = '';
+      }
     }
 
     for (const button of document.querySelectorAll('.nav-photos button')) {

--- a/optimize-images.js
+++ b/optimize-images.js
@@ -7,8 +7,8 @@ const root = path.resolve(process.cwd(), 'images');
 const optimizedImagesRoot = path.resolve(process.cwd(), 'images-optimized');
 const imageOptions = {
   committee: '200x200',
-  ['pre-pre-dies']: '250,scale-down',
-  ['pre-dies']: '250,scale-down'
+  ['pre-pre-dies']: '200,scale-down',
+  ['pre-dies']: '200,scale-down'
 };
 
 // Optimize images with ImageOptim

--- a/style.css
+++ b/style.css
@@ -55,6 +55,12 @@ h2 {
   color: black;
 }
 
+@media (max-width: 850px) {
+  h2 {
+    font-size: 10vw;
+  }
+}
+
 h3 {
   font-size: 2vw;
   text-align: center;
@@ -93,11 +99,55 @@ button:hover {
   display: flex;
   font-size: 3vw;
 }
+@media (max-width: 850px) {
+  #counter {
+    font-size: 5vw;
+  }
+}
 #counter > div {
   display: flex;
   flex-direction: column;
   flex: 1;
 }
+
+.photo-columns {
+  display: flex;
+  flex-wrap: wrap;
+}
+.photo-columns h3 {
+  color: white;
+  font-size: 3vw;
+}
+
+.leaderboard {
+  flex: 1;
+  margin: 0;
+  min-width: 400px;
+}
+.leaderboard ol {
+  font-size: 4vw;
+  margin-left: 50px;
+}
+
+.photos {
+  flex: 2;
+  min-width: 400px;
+}
+@media (max-width: 450px) {
+  .photos {
+    min-width: 100%;
+  }
+}
+.photos nav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
+}
+.photos nav a {
+  font-size: 1vw;
+  margin-right: 1vw;
+}
+
 .actual-photos {
   display: none;
   flex-wrap: wrap;
@@ -108,40 +158,21 @@ button:hover {
   margin: auto;
   text-align: center;
   margin-bottom: 15px;
-}
-@media (max-width: 850px) {
-  .actual-photos img {
-    width: 100px;
-  }
+  margin-right: 5px;
+  min-width: 190px;
 }
 
-.photo-columns {
+#program .content {
   display: flex;
+  flex-wrap: wrap;
 }
-.photo-columns h3 {
-  color: white;
-  font-size: 3vw;
-}
-.leaderboard {
+#program .days {
   flex: 1;
-  margin: 0;
+  min-width: 400px;
 }
-.photos {
+#program .extra-info {
   flex: 2;
-}
-
-.photos nav {
-  display: flex;
-  justify-content: space-around;
-}
-
-.photos nav a {
-  font-size: 1vw;
-  margin-right: 1vw;
-}
-
-.leaderboard ol {
-  font-size: 1.5vw;
+  min-width: 300px;
 }
 #program h4 {
   text-align: center;
@@ -149,18 +180,9 @@ button:hover {
   color: var(--main-color);
   font-size: 25px;
 }
-#program .days {
-  flex: 1;
-}
-#program .extra-info {
-  flex: 2;
-}
 #program .days > div > div {
   display: flex;
   justify-content: space-around;
-}
-#program .content {
-  display: flex;
 }
 #program h3 {
   text-align: center;
@@ -182,8 +204,14 @@ button:hover {
   text-align: center;
   font-size: 3vw;
 }
+
+#committee > div {
+  max-width: 100%;
+}
+
 .committee-members {
   display: flex;
+  flex-wrap: wrap;
   padding-bottom: 50px;
 }
 .committee-members > div {
@@ -191,12 +219,18 @@ button:hover {
   display: flex;
   flex-direction: column;
   text-align: center;
+  min-width: 200px;
+  max-width: 250px;
 }
 .committee-members img {
   border-radius: 50%;
   width: 80%;
   margin: auto;
 }
-#committee > div {
-  max-width: 100%;
+
+@media (max-width: 1400px) {
+  .committee-members > div {
+    min-width: 300px;
+    margin: auto;
+  }
 }

--- a/style.css
+++ b/style.css
@@ -162,6 +162,10 @@ button:hover {
   min-width: 190px;
 }
 
+.actual-photos img {
+  width: 250px;
+}
+
 #program .content {
   display: flex;
   flex-wrap: wrap;

--- a/style.css
+++ b/style.css
@@ -85,10 +85,16 @@ button:active {
 .cheers {
   font-size: 20vw;
 }
+/* 4k screens are this wide :O */
+@media (min-width: 2000px) {
+  .cheers {
+    font-size: 350px;
+  }
+}
 
 .intro > div {
-  background-size: 50%;
   background: url("images-optimized/cheers.png") no-repeat center;
+  background-size: 50%;
   margin: auto;
   display: block;
 }
@@ -122,9 +128,20 @@ button:active {
   margin: 0;
   min-width: 400px;
 }
+@media (max-width: 400px) {
+  .leaderboard {
+    min-width: 100%;
+  }
+}
 .leaderboard ol {
   font-size: 4vw;
   margin-left: 50px;
+}
+/* 4k screens are this wide :O */
+@media (min-width: 2000px) {
+  .leaderboard ol {
+    font-size: 75px;
+  }
 }
 
 .photos {
@@ -147,8 +164,9 @@ button:active {
 }
 
 .actual-photos {
-    display: none;
-    flex-wrap: wrap;
+  display: none;
+  flex-wrap: wrap;
+  text-align: center;
 }
 .photos nav :hover {
   color: var(--main-color);
@@ -173,9 +191,6 @@ button:active {
   box-shadow: white 0 0 0 40px inset;
 }
 
-.leaderboard ol {
-  font-size: 1.5vw;
-}
 .actual-photos > div {
   display: flex;
   flex-direction: column;
@@ -185,10 +200,18 @@ button:active {
   margin-right: 5px;
   min-width: 190px;
 }
-
 .actual-photos img {
   width: 250px;
 }
+@media (max-width: 520px), (min-width: 800px) and (max-width: 910px) {
+  .actual-photos > div {
+    width: 100%;
+  }
+  .actual-photos img {
+    margin: auto;
+  }
+}
+
 
 #program .content {
   display: flex;
@@ -197,6 +220,11 @@ button:active {
 #program .days {
   flex: 1;
   min-width: 400px;
+}
+@media (max-width: 400px) {
+  #program .days {
+    min-width: 100%;
+  }
 }
 #program .extra-info {
   flex: 2;
@@ -259,15 +287,13 @@ button:active {
   .shoutouts h3 {
     font-size: 6vw;
   }
-  .committee-members {
-    max-width: 100px;
-  }
 }
 
 .committee-members {
   display: flex;
   flex-wrap: wrap;
   padding-bottom: 50px;
+  justify-content: center;
 }
 .committee-members > div {
   flex: 1;
@@ -279,7 +305,7 @@ button:active {
 }
 .committee-members img {
   border-radius: 50%;
-  width: 40%;
+  width: 80%;
   margin: auto;
 }
 

--- a/style.css
+++ b/style.css
@@ -259,6 +259,9 @@ button:active {
   .shoutouts h3 {
     font-size: 6vw;
   }
+  .committee-members {
+    max-width: 100px;
+  }
 }
 
 .committee-members {
@@ -276,7 +279,7 @@ button:active {
 }
 .committee-members img {
   border-radius: 50%;
-  width: 80%;
+  width: 40%;
   margin: auto;
 }
 


### PR DESCRIPTION
Mostly this was setting `min-width` on items inside flex styled elements. Also the committee member images are now properly spacing on 2 levels. Lastly, lazy-load the images by first putting it in a `data-src` so that we are not loading every single image on the page at once.